### PR TITLE
Add SearchResultContext file

### DIFF
--- a/src/contexts/SearchResultContext.tsx
+++ b/src/contexts/SearchResultContext.tsx
@@ -5,7 +5,7 @@ type TDrinkValue = IDrinkReformat[] | null;
 
 interface ISearchContext {
   searchResults: TDrinkValue;
-  setSearcResults: React.Dispatch<React.SetStateAction<TDrinkValue>>;
+  setSearchResults: React.Dispatch<React.SetStateAction<TDrinkValue>>;
 }
 
 interface ISearchContextProviderProps {
@@ -16,10 +16,10 @@ const SearchContext = createContext<ISearchContext | null>(null);
 
 // Used to wrap any children components that need access to reading/updating the searchResults
 export function SearchContextProvider({ children }: ISearchContextProviderProps) {
-  const [searchResults, setSearcResults] = useState<TDrinkValue>(null);
+  const [searchResults, setSearchResults] = useState<TDrinkValue>(null);
 
   return (
-    <SearchContext.Provider value={{ searchResults, setSearcResults }}>
+    <SearchContext.Provider value={{ searchResults, setSearchResults }}>
       {children}
     </SearchContext.Provider>
   );

--- a/src/contexts/SearchResultContext.tsx
+++ b/src/contexts/SearchResultContext.tsx
@@ -1,0 +1,39 @@
+import { createContext, ReactNode, useContext, useState } from "react";
+import { IDrinkReformat } from "../interfaces";
+
+type TDrinkValue = IDrinkReformat[] | null;
+
+interface ISearchContext {
+  searchResults: TDrinkValue;
+  setSearcResults: React.Dispatch<React.SetStateAction<TDrinkValue>>;
+}
+
+interface ISearchContextProviderProps {
+  children: ReactNode;
+}
+
+const SearchContext = createContext<ISearchContext | null>(null);
+
+// Used to wrap any children components that need access to reading/updating the searchResults
+export function SearchContextProvider({ children }: ISearchContextProviderProps) {
+  const [searchResults, setSearcResults] = useState<TDrinkValue>(null);
+
+  return (
+    <SearchContext.Provider value={{ searchResults, setSearcResults }}>
+      {children}
+    </SearchContext.Provider>
+  );
+}
+
+// Custom hook for the search context to avoid repeating code in components that use it
+export function useSearchContext() {
+  const context = useContext(SearchContext);
+
+  // If you try to use this context outside of SearchContextProvider, throw an error to
+  // notify the developer
+  if (!context) {
+    throw new Error("useSearchContext must be used within SearchContextProvider");
+  }
+
+  return context;
+}

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -75,8 +75,8 @@ export interface IDrinkReformat {
   strInstructionsDE: TOptionalString;
   strInstructionsFR: TOptionalString;
   strInstructionsIT: TOptionalString;
-  strInstructionsZH_HANS: TOptionalString;
-  strInstructionsZH_HANT: TOptionalString;
+  "strInstructionsZH-HANS": TOptionalString;
+  "strInstructionsZH-HANT": TOptionalString;
   strDrinkThumb: string;
   strIngredients: IDrinkIngredients[];
   strImageSource: TOptionalString;


### PR DESCRIPTION
Added a file which exports a SearchContextProvider and a useSearchContext hook.

`useSearchContext` will return searchResults and setSearchResults. You can destructure both or just one of them when calling `useSearchContext`. Ex. `const {searchResults, setSearchResults} = useSearchContext();`

**Usage SearchContextProvider**
```tsx
// In App.tsx
import { SearchContextProvider } from './contexts/SearchResultContext';

function App() {

  return (
    <>
      <SearchContextProvider>
        <Outlet />
      </SearchContextProvider>
    </>
  );
}
```

**Usage useSearchContext** (in ex. Search Component)
```tsx
import { useSearchContext } from "../contexts/SearchResultContext"

export function Search() {
  // Now you can use setSearchResults as you would a normal setter function with useState
  const {setSearchResults} = useSearchContext();

  return (
    <div>Search</div>
  )
}
```
**If you wanted to use the results**
```tsx
import { useSearchContext } from "../contexts/SearchResultContext"

export function ListResults() {
  // Now you can read searchResults as you would normally do with useState
  const {searchResults} = useSearchContext();

  return (
    <div>ListResults</div>
  )
}
```
