### PR TITLE
Small css fixes

### DIFF
--- a/src/components/CocktailCard.tsx
+++ b/src/components/CocktailCard.tsx
@@ -17,9 +17,10 @@ export const CocktailCard = ({ cocktail }: ICocktailCardProps): React.ReactEleme
 
       <h3 className="cocktailcard-info">{cocktail.name}</h3>
 
-      <p>
+      <Link className="link-more-info" to={`/details/${cocktail.id}`}>More info</Link>
+      {/* <p>
         <Link to={`/details/${cocktail.id}`}>More info</Link>
-      </p>
+      </p> */}
     </article>
   );
 };

--- a/src/components/CocktailCard.tsx
+++ b/src/components/CocktailCard.tsx
@@ -18,9 +18,6 @@ export const CocktailCard = ({ cocktail }: ICocktailCardProps): React.ReactEleme
       <h3 className="cocktailcard-info">{cocktail.name}</h3>
 
       <Link className="link-more-info" to={`/details/${cocktail.id}`}>More info</Link>
-      {/* <p>
-        <Link to={`/details/${cocktail.id}`}>More info</Link>
-      </p> */}
     </article>
   );
 };

--- a/src/components/ListResults.tsx
+++ b/src/components/ListResults.tsx
@@ -23,9 +23,7 @@ export function ListResults() {
     <section className="list-container">
       <section className="list-results">
         {currentPosts.map((cocktail) => (
-          <div key={cocktail.id} className="drink-card">
-            <CocktailCard cocktail={cocktail} />
-          </div>
+          <CocktailCard key={cocktail.id} cocktail={cocktail} />
         ))}
       </section>
       <Pagination

--- a/src/css/CocktailCard.css
+++ b/src/css/CocktailCard.css
@@ -39,11 +39,12 @@
   padding: 10px 20px;
   border-radius: 10px;
   text-align: center;
+  pointer-events: none;
 }
 
 /* Button */
 
-.cocktail-card > p {
+.link-more-info {
   grid-column: 2;
   grid-row: 2;
   margin: 20px;
@@ -54,6 +55,7 @@
   padding: 10px 10px;
   border-radius: 10px;
   text-decoration: none;
+  text-align: center;
   font-weight: bold;
   transition: all 0.3s ease;
 }

--- a/src/css/CocktailDetails.css
+++ b/src/css/CocktailDetails.css
@@ -11,6 +11,10 @@
   gap: 1rem;
 }
 
+.cocktail-figure {
+  flex: 1 0 40%;
+}
+
 .cocktail-info {
   margin-left: 1rem;
   border-radius: 5px;

--- a/src/css/FavoritePage.css
+++ b/src/css/FavoritePage.css
@@ -5,8 +5,9 @@
 
 .favourite-cocktails-container {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  max-width: 70vw;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  justify-items: center;
+  max-width: 60vw;
   row-gap: 1rem;
   column-gap: 1rem;
   margin-bottom: 2rem;

--- a/src/css/ListResults.css
+++ b/src/css/ListResults.css
@@ -5,8 +5,8 @@
 
 .list-results {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  max-width: 70vw;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  max-width: 60vw;
   row-gap: 1rem;
   column-gap: 1rem;
   margin-bottom: 2rem;

--- a/src/css/Search.css
+++ b/src/css/Search.css
@@ -2,6 +2,10 @@
   margin-top: 1.5rem;
 }
 
+.search > form {
+  display: flex;
+}
+
 .search > form > input {
   border-radius: 1rem;
   border-style: none;

--- a/src/pages/CocktailDetailsPage.tsx
+++ b/src/pages/CocktailDetailsPage.tsx
@@ -45,14 +45,14 @@ export const CocktailDetailsPage = () => {
 
   return (
     <div className="cocktail-details">
-      <h1 className="cocktail-title">
+      <h1 className="cocktail-title uppercase">
         {cocktail.strDrink}
         <FavoriteButton cocktail={fetchedCocktail} />
       </h1>
 
       <div className="cocktail-details-wrapper">
         <figure className="cocktail-figure">
-          <img src={cocktail.strDrinkThumb} alt={cocktail.strDrink} style={{ width: "300px" }} />
+          <img src={cocktail.strDrinkThumb} alt={cocktail.strDrink} />
         </figure>
         <article className="cocktail-info">
           <h3>Ingredients</h3>

--- a/src/pages/IngredientPage.tsx
+++ b/src/pages/IngredientPage.tsx
@@ -17,7 +17,7 @@ export function IngredientPage() {
 
   return (
     <section className="ingredient-page">
-      <h1 className="ingredient-title">{ingredient.strIngredient}</h1>
+      <h1 className="ingredient-title uppercase">{ingredient.strIngredient}</h1>
       <article className="ingredient-details">
         <figure className="ingredient-figure">
           <img src={ingredientImage} alt={`Image of ${ingredient}`} />


### PR DESCRIPTION
- Fixed cocktail image being a bit small on CocktailDetailsPage. 
- Made titles on CocktailDetailsPage and IngredientPage uppercase to match the rest of the page.
- Fixed an issue where the title on CocktailCard would block the "More info" link from being clickable.
- Made it so the whole "More info" (button) is clickable instead of just the text inside it.
- Made the grids on SearchPage and FavoritePage more responsive, without adding media queries.
![cocktail-wiki-edits](https://github.com/user-attachments/assets/d2acad91-db73-4150-af5e-7c630410b551)
